### PR TITLE
Disposed objects are not handled properly in android scrollview renderer #5820

### DIFF
--- a/Xamarin.Forms.Platform.Android/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ScrollViewRenderer.cs
@@ -373,6 +373,10 @@ namespace Xamarin.Forms.Platform.Android
 			while (IsLayoutRequested)
 			{
 				await Task.Delay(TimeSpan.FromMilliseconds(1));
+				
+				if (_disposed)
+                	return;
+				
 				cycle++;
 
 				if (cycle >= 10)


### PR DESCRIPTION
### Description of Change ###
Object disposed exception raised when navigation back from page with SfListView in random cases. 
https://github.com/xamarin/Xamarin.Forms/issues/5820

### Issues Resolved ### 
Exception raised in random cases due to the delay we are making in OnScrollRequesed method. Now after the delay code added and returned based on _disposed flag status. 

### API Changes ###
None

### Platforms Affected ### 
- Android

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
